### PR TITLE
adds set up of config for API tests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,7 +27,7 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+    import_config "#{Mix.env}.exs"
 
 config :elixir_auth_github,
   client_id: "ef6730c4c96c4eb6f818",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :elixir_auth_github, :httpoison, ElixirAuthGithub.HTTPoison.HTTPoison

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :elixir_auth_github, :httpoison, ElixirAuthGithub.HTTPoison.InMemory

--- a/lib/elixir_auth_github.ex
+++ b/lib/elixir_auth_github.ex
@@ -6,6 +6,7 @@ defmodule ElixirAuthGithub do
   @client_id Application.get_env(:elixir_auth_github, :client_id)
   @client_secret Application.get_env(:elixir_auth_github, :client_secret)
   @github_auth_url "https://github.com/login/oauth/access_token?"
+  @httpoison Application.get_env(:elixir_auth_github, :httpoison)
 
   def login_url do
     case @client_id do
@@ -30,7 +31,7 @@ defmodule ElixirAuthGithub do
       "client_secret" => @client_secret,
       "code" => code}
     |> URI.encode_query
-    |> (&(HTTPoison.post!(@github_auth_url <> &1, ""))).()
+    |> (&(@httpoison.post!(@github_auth_url <> &1, ""))).()
     |> Map.get(:body)
     |> URI.decode_query
     |> get_user_details
@@ -41,7 +42,7 @@ defmodule ElixirAuthGithub do
 
 
   def get_user_details(%{"access_token" => access_token}) do
-    HTTPoison.get!("https://api.github.com/user", [
+    @httpoison.get!("https://api.github.com/user", [
       {"User-Agent", "elixir-practice"},
       {"Authorization", "token #{access_token}"}
     ])

--- a/lib/httpoison/httpoison.ex
+++ b/lib/httpoison/httpoison.ex
@@ -1,0 +1,7 @@
+defmodule ElixirAuthGithub.HTTPoison.HTTPoison do
+  import HTTPoison
+
+  defdelegate get!(url, headers, options \\ []), to: HTTPoison
+
+  defdelegate post!(url, body, headers \\ [], options \\ []), to: HTTPoison
+end

--- a/lib/httpoison/in_memory.ex
+++ b/lib/httpoison/in_memory.ex
@@ -1,0 +1,13 @@
+defmodule ElixirAuthGithub.HTTPoison.InMemory do
+  import HTTPoison
+
+  def get!(_url, _headers \\ [], _options \\ []) do
+    ## @TODO add actual stuff what htis should return
+    %{body: "{\"key\": \"value\"}"}
+  end
+
+  def post!(_url, _body, _headers \\ [], _options \\ []) do
+    ## @TODO add actual stuff what htis should return
+    %{body: "access_token=HELLO"}
+  end
+end


### PR DESCRIPTION
We have a config set up so that in "test" MIX_ENV our functions which usually talk to github just return some dummy data. This will help with testing. 

#4 